### PR TITLE
Add headless GUI tests to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,19 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake ninja-build pkg-config
-        # Note: No GUI dependencies needed for tests-only build
+        sudo apt-get install -y \
+          build-essential \
+          cmake \
+          ninja-build \
+          pkg-config \
+          xvfb \
+          libgl1-mesa-dev \
+          libglu1-mesa-dev \
+          libxrandr-dev \
+          libxinerama-dev \
+          libxcursor-dev \
+          libxi-dev
+        # Dependencies cover both console unit tests and headless GUI tests
     
     - name: Configure CMake (Tests Only)
       working-directory: imgui_opengl_glad
@@ -77,7 +88,7 @@ jobs:
       run: |
         cd build_tests
         ctest --verbose --output-on-failure
-    
+
     - name: Upload test results
       uses: actions/upload-artifact@v4
       if: always()
@@ -86,6 +97,27 @@ jobs:
         path: |
           imgui_opengl_glad/build_tests/Testing/**/*.xml
           imgui_opengl_glad/build_tests/Testing/**/*.log
+
+    - name: Install vcpkg (for GUI tests)
+      run: |
+        git clone https://github.com/microsoft/vcpkg.git
+        ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+    - name: Configure GUI tests
+      run: |
+        cmake -B build_gui_tests -S imgui_opengl_glad/tests/guitests \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake \
+          -DVCPKG_TARGET_TRIPLET=x64-linux
+
+    - name: Build GUI tests
+      run: |
+        cmake --build build_gui_tests --config Release
+
+    - name: Run GUI tests headless
+      run: |
+        xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' \
+          ./build_gui_tests/simple_gui_test --headless
 
   code-quality:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- install the Linux packages needed to run ImGui GUI tests in headless mode
- bootstrap vcpkg and build the GUI test target during the Linux CI job
- execute the simple_gui_test suite under xvfb to validate GUI behavior in CI

## Testing
- not run (pipeline change only)


------
https://chatgpt.com/codex/tasks/task_e_68e29a3594588323b4eddc853c623f13