### PR TITLE
Run GUI tests on Windows in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,45 @@ jobs:
       run: |
         # Run build script which now supports both PowerShell Core and Windows PowerShell
         .\build_tests_only.bat
-    
+
+    - name: Install vcpkg (for GUI tests)
+      shell: powershell
+      run: |
+        if (-Not (Test-Path "vcpkg")) {
+          git clone https://github.com/microsoft/vcpkg.git
+        }
+        .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
+
+    - name: Install GUI dependencies
+      shell: powershell
+      run: |
+        # Use manifest mode to install the dependencies declared in vcpkg.json
+        .\vcpkg\vcpkg.exe install --triplet x64-windows
+
+    - name: Configure GUI tests
+      shell: powershell
+      run: |
+        cmake -B build_gui_tests -S imgui_opengl_glad/tests/guitests `
+          -DCMAKE_BUILD_TYPE=Release `
+          -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake" `
+          -DVCPKG_TARGET_TRIPLET=x64-windows
+
+    - name: Build GUI tests
+      shell: powershell
+      run: |
+        cmake --build build_gui_tests --config Release
+
+    - name: Run GUI tests
+      shell: powershell
+      run: |
+        $buildDir = (Resolve-Path build_gui_tests).Path
+        $testExe = Join-Path $buildDir "Release\\simple_gui_test.exe"
+        if (-Not (Test-Path $testExe)) {
+          Write-Error "GUI test executable not found: $testExe"
+          exit 1
+        }
+        & $testExe --headless
+
     - name: Upload test results
       uses: actions/upload-artifact@v4
       if: always()
@@ -77,7 +115,7 @@ jobs:
       run: |
         cd build_tests
         ctest --verbose --output-on-failure
-    
+
     - name: Upload test results
       uses: actions/upload-artifact@v4
       if: always()


### PR DESCRIPTION
## Summary
- run `vcpkg install` in manifest mode so the glad and glfw3 dependencies from vcpkg.json are available before configuring the Windows GUI tests

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e29a3594588323b4eddc853c623f13