### PR TITLE
Install Mesa runtime for Windows GUI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,42 @@ jobs:
         }
         .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
 
+    - name: Install Mesa software OpenGL runtime
+      shell: powershell
+      run: |
+        $headers = @{ "User-Agent" = "actions" }
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/pal1000/mesa-dist-win/releases/latest" -Headers $headers
+        $asset = $release.assets | Where-Object { $_.name -like "mesa3d-*-release-msvc.zip" } | Select-Object -First 1
+        if (-not $asset) {
+          Write-Error "Unable to locate Mesa release asset"
+          exit 1
+        }
+
+        $zipPath = Join-Path $env:RUNNER_TEMP "mesa3d.zip"
+        Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zipPath
+
+        $extractDir = Join-Path $env:RUNNER_TEMP "mesa"
+        if (Test-Path $extractDir) {
+          Remove-Item $extractDir -Recurse -Force
+        }
+        Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+        $mesaRoot = Get-ChildItem $extractDir -Directory | Select-Object -First 1
+        if (-not $mesaRoot) {
+          Write-Error "Mesa extraction directory not found"
+          exit 1
+        }
+
+        $mesaBin = Join-Path $mesaRoot.FullName "x64"
+        if (-not (Test-Path $mesaBin)) {
+          Write-Error "Mesa x64 binaries not found"
+          exit 1
+        }
+
+        Add-Content -Path $env:GITHUB_ENV -Value "MESA_DIST_DIR=$mesaBin"
+        Add-Content -Path $env:GITHUB_PATH -Value $mesaBin
+        Write-Host "Mesa software OpenGL runtime installed at $mesaBin"
+
     - name: Install GUI dependencies
       shell: powershell
       env:
@@ -75,9 +111,23 @@ jobs:
       run: |
         $buildDir = (Resolve-Path build_gui_tests).Path
         $testExe = Join-Path $buildDir "Release\\simple_gui_test.exe"
+        $mesaDir = $env:MESA_DIST_DIR
         if (-Not (Test-Path $testExe)) {
           Write-Error "GUI test executable not found: $testExe"
           exit 1
+        }
+        if ($mesaDir -and (Test-Path $mesaDir)) {
+          $outputDir = Split-Path $testExe -Parent
+          foreach ($dll in "opengl32.dll", "libglapi.dll", "libgallium_wgl.dll") {
+            $source = Join-Path $mesaDir $dll
+            if (Test-Path $source) {
+              Copy-Item $source $outputDir -Force
+            } else {
+              Write-Warning "Mesa component missing: $source"
+            }
+          }
+        } else {
+          Write-Warning "Mesa directory not found. GUI tests may fail due to missing OpenGL runtime."
         }
         & $testExe --headless
 


### PR DESCRIPTION
## Summary
- install the Mesa software OpenGL runtime in the Windows GUI test workflow
- copy the Mesa DLLs beside the test executable so headless GUI tests can create an OpenGL context

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2b5347e2c8323943601a82b6307bf