### PR TITLE
Handle Mesa archives compressed as 7z in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,20 +51,40 @@ jobs:
       run: |
         $headers = @{ "User-Agent" = "actions" }
         $release = Invoke-RestMethod -Uri "https://api.github.com/repos/pal1000/mesa-dist-win/releases/latest" -Headers $headers
-        $asset = $release.assets | Where-Object { $_.name -like "mesa3d-*-release-msvc.zip" } | Select-Object -First 1
+        $asset = $release.assets | Where-Object {
+          $_.name -like "mesa3d-*-release-msvc.zip" -or $_.name -like "mesa3d-*-release-msvc.7z"
+        } | Select-Object -First 1
         if (-not $asset) {
           Write-Error "Unable to locate Mesa release asset"
           exit 1
         }
 
-        $zipPath = Join-Path $env:RUNNER_TEMP "mesa3d.zip"
-        Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zipPath
+        $extension = [System.IO.Path]::GetExtension($asset.name)
+        $archivePath = Join-Path $env:RUNNER_TEMP ("mesa3d" + $extension)
+        Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $archivePath
 
         $extractDir = Join-Path $env:RUNNER_TEMP "mesa"
         if (Test-Path $extractDir) {
           Remove-Item $extractDir -Recurse -Force
         }
-        Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+        switch ($extension.ToLowerInvariant()) {
+          '.zip' {
+            Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+          }
+          '.7z' {
+            $sevenZip = Get-Command 7z.exe -ErrorAction SilentlyContinue
+            if (-not $sevenZip) {
+              choco install 7zip -y --no-progress | Out-Null
+              $sevenZip = Get-Command 7z.exe -ErrorAction Stop
+            }
+            & $sevenZip.Path x $archivePath "-o$extractDir" -y | Out-Null
+          }
+          Default {
+            Write-Error "Unsupported Mesa archive type: $extension"
+            exit 1
+          }
+        }
 
         $mesaRoot = Get-ChildItem $extractDir -Directory | Select-Object -First 1
         if (-not $mesaRoot) {


### PR DESCRIPTION
## Summary
- allow the Windows Mesa install step to match either .zip or .7z release assets
- install 7-Zip on demand so the workflow can extract .7z archives

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2b6acd0b083239ebbba8d382d0b26